### PR TITLE
Display the typesetting task on the review page.

### DIFF
--- a/templates/typesetting/elements/galleys_with_help_text.html
+++ b/templates/typesetting/elements/galleys_with_help_text.html
@@ -1,0 +1,5 @@
+<p><small>Any galleys (typeset files) that were selected by the editor
+  for correction, or that you originally uploaded, will appear here. Ensure
+  that any image files that belong with XML files are uploaded using the
+  upload images function and not as typeset files.</small></p>
+{% include "typesetting/elements/typesetter/galleys.html" with disable_upload=disable_upload %}

--- a/templates/typesetting/elements/typesetter/galleys.html
+++ b/templates/typesetting/elements/typesetter/galleys.html
@@ -51,9 +51,11 @@
     {% endfor %}
 </table>
 
+{% if not disable_upload %}
 <div class="button-group">
     <a class="float-right button success" data-open="uploadbox">
         <span class="fa fa-cloud-upload"></span>
         Upload New Typeset File
     </a>
 </div>
+{% endif %}

--- a/templates/typesetting/typesetting_assignment.html
+++ b/templates/typesetting/typesetting_assignment.html
@@ -56,11 +56,7 @@
                     <h2>Upload Galleys</h2>
                 </div>
                 <div class="content">
-                    <p><small>Any galleys (typeset files) that were selected by the editor
-                    for correction, or that you originally uploaded, will appear here. Ensure
-                    that any image files that belong with XML files are uploaded using the
-                    upload images function and not as typeset files.</small></p>
-                    {% include "typesetting/elements/typesetter/galleys.html" %}
+                  {% include "typesetting/elements/galleys_with_help_text.html" %}
                 </div>
                 <div class="title-area">
                     <h2>Upload Source Files</h2>

--- a/templates/typesetting/typesetting_review_assignment.html
+++ b/templates/typesetting/typesetting_review_assignment.html
@@ -47,16 +47,6 @@
                 {{ assignment.completed|bool_fa }}{% endif %}</td>
               <td>{{ assignment.status|capfirst }}</td>
             </tr>
-            {% if assignment.accepted %}
-              <tr>
-                <th colspan="7">Note from Typesetter</th>
-              </tr>
-              <tr>
-                <td colspan="7">
-                  {{ assignment.typesetter_note|safe|default:"No typesetter note recorded." }}
-                </td>
-              </tr>
-            {% endif %}
           </table>
         </div>
         <div class="title-area">
@@ -64,6 +54,28 @@
         </div>
         <div class="content">
           {{ assignment.task|safe|default:"No typesetting task was recorded." }}
+        </div>
+        {% if assignment.accepted %}
+        <div class="title-area">
+          <h2>Note from Typesetter</h2>
+        </div>
+        <div class="content">
+          {{ assignment.typesetter_note|safe|default:"No typesetter note recorded." }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  <div class="row expanded">
+    <div class="large-12 columns">
+      <div class="box">
+        <div class="title-area">
+          <h2>Selected Files</h2>
+        </div>
+        <div class="content">
+          <p>These are the files that the typesetter was given access to during this round of typesetting.</p>
+          {% include "typesetting/elements/file_list.html" with files=assignment.files_to_typeset.all input_name="files_to_typeset" %}
         </div>
       </div>
     </div>

--- a/templates/typesetting/typesetting_review_assignment.html
+++ b/templates/typesetting/typesetting_review_assignment.html
@@ -60,7 +60,7 @@
           <h2>Note from Typesetter</h2>
         </div>
         <div class="content">
-          {{ assignment.typesetter_note|safe|default:"No typesetter note recorded." }}
+          {{ assignment.typesetter_note|safe|default:"No typesetter note was recorded." }}
         </div>
         {% endif %}
       </div>

--- a/templates/typesetting/typesetting_review_assignment.html
+++ b/templates/typesetting/typesetting_review_assignment.html
@@ -16,48 +16,58 @@
 {% endblock breadcrumbs %}
 
 {% block body %}
-    <div class="row expanded">
+  <div class="row expanded">
+    <div class="large-12 columns">
       <div class="box">
-          <div class="title-area">
-              <h2>Typesetting worked on
-                  by {{ assignment.typesetter.full_name }}</h2>
-              <a href="{% url 'typesetting_article' article.pk %}" class="button">< Back</a>
-          </div>
-          <div class="content">
-              <table class="table small">
-                  <tr>
-                      <th>ID</th>
-                      <th>Manager</th>
-                      <th>Created</th>
-                      <th>Due</th>
-                      <th>Accepted</th>
-                      <th>Completed</th>
-                      <th>Status</th>
-                  </tr>
-                  <tr>
-                      <td>{{ assignment.pk }}</td>
-                      <td>{{ assignment.manager.full_name }}</td>
-                      <td>{{ assignment.assigned|date }}</td>
-                      <td>{{ assignment.due|date }}</td>
-                      <td>{{ assignment.accepted|date }}</td>
-                      <td>{% if assignment.completed %}
-                          {{ assignment.completed|date }}{% else %}
-                          {{ assignment.completed|bool_fa }}{% endif %}</td>
-                      <td>{{ assignment.status|capfirst }}</td>
-                  </tr>
-                  {% if assignment.accepted %}
-                      <tr>
-                          <th colspan="7">Note from Typesetter</th>
-                      </tr>
-                      <tr>
-                          <td colspan="7">{{ assignment.typesetter_note|safe }}</td>
-                      </tr>
-                  {% endif %}
-              </table>
-          </div>
-          </div>
+        <div class="title-area">
+          <h2>Typesetting worked on
+            by {{ assignment.typesetter.full_name }}</h2>
+          <a href="{% url 'typesetting_article' article.pk %}" class="button"><
+            Back</a>
+        </div>
+        <div class="content">
+          <table class="table small">
+            <tr>
+              <th>ID</th>
+              <th>Manager</th>
+              <th>Created</th>
+              <th>Due</th>
+              <th>Accepted</th>
+              <th>Completed</th>
+              <th>Status</th>
+            </tr>
+            <tr>
+              <td>{{ assignment.pk }}</td>
+              <td>{{ assignment.manager.full_name }}</td>
+              <td>{{ assignment.assigned|date }}</td>
+              <td>{{ assignment.due|date }}</td>
+              <td>{{ assignment.accepted|date }}</td>
+              <td>{% if assignment.completed %}
+                {{ assignment.completed|date }}{% else %}
+                {{ assignment.completed|bool_fa }}{% endif %}</td>
+              <td>{{ assignment.status|capfirst }}</td>
+            </tr>
+            {% if assignment.accepted %}
+              <tr>
+                <th colspan="7">Note from Typesetter</th>
+              </tr>
+              <tr>
+                <td colspan="7">
+                  {{ assignment.typesetter_note|safe|default:"No typesetter note recorded." }}
+                </td>
+              </tr>
+            {% endif %}
+          </table>
+        </div>
+        <div class="title-area">
+          <h2>Typesetting Task</h2>
+        </div>
+        <div class="content">
+          {{ assignment.task|safe|default:"No typesetting task was recorded." }}
+        </div>
       </div>
     </div>
+  </div>
 
     <div class="row expanded">
         <div class="large-12 columns">

--- a/templates/typesetting/typesetting_review_assignment.html
+++ b/templates/typesetting/typesetting_review_assignment.html
@@ -71,11 +71,14 @@
     <div class="large-12 columns">
       <div class="box">
         <div class="title-area">
-          <h2>Selected Files</h2>
+          <h2>Files</h2>
         </div>
         <div class="content">
-          <p>These are the files that the typesetter was given access to during this round of typesetting.</p>
+          <p><small>These are the files that the typesetter was given access to during this round of typesetting.</small></p>
           {% include "typesetting/elements/file_list.html" with files=assignment.files_to_typeset.all input_name="files_to_typeset" %}
+        </div>
+        <div class="content">
+          {% include "typesetting/elements/galleys_with_help_text.html" with disable_upload="y" %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adds the typesetting assignment task field to the assignment review page. Also adds a default to typesetter note.

Closes #217 

Additionally this fixes some odd display issue where one box was large than the others.

<img width="1940" alt="image" src="https://github.com/user-attachments/assets/9b83fab5-6beb-484f-bf32-a75687bbe3a4">
